### PR TITLE
[IMP] enable feature & cover multiple cashiers

### DIFF
--- a/pos_receipt_replace_user_by_trigram/__manifest__.py
+++ b/pos_receipt_replace_user_by_trigram/__manifest__.py
@@ -11,7 +11,7 @@
     "installable": True,
     "version": "16.0.1.0.0",
     "depends": [
-        "point_of_sale",
+        "pos_hr",
         "partner_firstname",
     ],
     "assets": {

--- a/pos_receipt_replace_user_by_trigram/models/__init__.py
+++ b/pos_receipt_replace_user_by_trigram/models/__init__.py
@@ -1,4 +1,5 @@
 from . import pos_config
 from . import res_config_settings
-from . import res_users
+from . import res_partner
+from . import hr_employee
 from . import pos_session

--- a/pos_receipt_replace_user_by_trigram/models/hr_employee.py
+++ b/pos_receipt_replace_user_by_trigram/models/hr_employee.py
@@ -1,0 +1,9 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models, api
+
+class HrEmployee(models.Model):
+    _inherit = "hr.employee"
+
+    pos_trigram = fields.Char(related="work_contact_id.pos_trigram")

--- a/pos_receipt_replace_user_by_trigram/models/pos_config.py
+++ b/pos_receipt_replace_user_by_trigram/models/pos_config.py
@@ -8,5 +8,5 @@ class PosConfig(models.Model):
     _inherit = "pos.config"
 
     replace_user_by_trigram = fields.Boolean(
-        default=False, string="Replace User by trigram in POS receipt"
+        default=True, string="Replace User by trigram in POS receipt"
     )

--- a/pos_receipt_replace_user_by_trigram/models/pos_session.py
+++ b/pos_receipt_replace_user_by_trigram/models/pos_session.py
@@ -10,3 +10,8 @@ class POSSession(models.Model):
         res = super()._loader_params_res_users()
         res["search_params"]["fields"].extend(["pos_trigram"])
         return res
+
+    def _loader_params_hr_employee(self):
+        res = super()._loader_params_hr_employee()
+        res["search_params"]["fields"].extend(["pos_trigram"])
+        return res

--- a/pos_receipt_replace_user_by_trigram/models/res_partner.py
+++ b/pos_receipt_replace_user_by_trigram/models/res_partner.py
@@ -1,17 +1,15 @@
 # Copyright 2024 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
-
+from odoo import fields, models, api
 from .. import utils
 
-
-class ResUsers(models.Model):
-    _inherit = "res.users"
+class ResPartner(models.Model):
+    _inherit = "res.partner"
 
     pos_trigram = fields.Char(compute="_compute_pos_trigram")
 
     @api.depends("firstname", "lastname")
     def _compute_pos_trigram(self):
-        for user in self:
-            user.pos_trigram = utils.get_trigram(user.firstname, user.lastname)
+        for partner in self:
+            partner.pos_trigram = utils.get_trigram(partner.firstname, partner.lastname)


### PR DESCRIPTION
### Major change

1. pos_trigram is defined in `res.partner` instead of res.users.

    - res.users inherits `res.partner`
    - can link `res.partner` and `hr.employee` via related field `work_contact_id`

2. Depends on `pos_hr` instead of `point_of_sale`

    - As feature 'switching cashier' is on, `get_cashier` method is overridden.I take advantage of the module to pass the field `pos_trigram` into `_loader_params_hr_employee`, so it can be accessed on model Pos Order