### PR TITLE
[16.0][IMP] pos_product_label: improve print_product_labels

### DIFF
--- a/pos_product_label/README.rst
+++ b/pos_product_label/README.rst
@@ -71,6 +71,10 @@ Contributors
 
   * Iván Todorovich <ivan.todorovich@camptocamp.com>
 
+* [Trobz](https://www.trobz.com):
+
+  * Tri Doan <tridm@trobz.com>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/pos_product_label/models/pos_session.py
+++ b/pos_product_label/models/pos_session.py
@@ -8,6 +8,17 @@ from odoo.tools import plaintext2html
 class PosSession(models.Model):
     _inherit = "pos.session"
 
+    def _prepare_product_label_layout_data(self, data):
+        vals = {
+            "product_ids": [Command.set(data["product_ids"])],
+            "custom_quantity": data["custom_quantity"],
+            "print_format": data["print_format"],
+            "extra_html": (
+                plaintext2html(data["extra_html"]) if data.get("extra_html") else False
+            ),
+        }
+        return vals
+
     def print_product_labels(self, data):
         """Print product labels from the POS.
 
@@ -19,18 +30,8 @@ class PosSession(models.Model):
             - print_format: str
             - extra_html: str
         """
-        wizard = self.env["product.label.layout"].create(
-            {
-                "product_ids": [Command.set(data["product_ids"])],
-                "custom_quantity": data["custom_quantity"],
-                "print_format": data["print_format"],
-                "extra_html": (
-                    plaintext2html(data["extra_html"])
-                    if data.get("extra_html")
-                    else False
-                ),
-            }
-        )
+        vals = self.prepare_product_label_layout_data(data)
+        wizard = self.env["product.label.layout"].create(vals)
         if data.get("pos_quantity") == "order":
             wizard = wizard.with_context(
                 force_label_qty_by_product=data.get("order_quantity_by_product", {})

--- a/pos_product_label/readme/CONTRIBUTORS.rst
+++ b/pos_product_label/readme/CONTRIBUTORS.rst
@@ -1,3 +1,7 @@
 * `Camptocamp <https://www.camptocamp.com>`_
 
   * Iván Todorovich <ivan.todorovich@camptocamp.com>
+
+* [Trobz](https://www.trobz.com):
+
+  * Tri Doan <tridm@trobz.com>

--- a/pos_product_label/static/description/index.html
+++ b/pos_product_label/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -416,6 +415,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li><a class="reference external" href="https://www.camptocamp.com">Camptocamp</a><ul>
 <li>Iván Todorovich &lt;<a class="reference external" href="mailto:ivan.todorovich&#64;camptocamp.com">ivan.todorovich&#64;camptocamp.com</a>&gt;</li>
+</ul>
+</li>
+<li>[Trobz](<a class="reference external" href="https://www.trobz.com">https://www.trobz.com</a>):<ul>
+<li>Tri Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
### This change

- Decouple `print_product_labels` for better inheritance. Notably, print label with extra information such as packaging. Hence, `prepare_product_label_layout_data` is used to add more data.